### PR TITLE
Generative behavior pipeline 

### DIFF
--- a/weinhardt2026/studies/hwang2026/analysis_generative.py
+++ b/weinhardt2026/studies/hwang2026/analysis_generative.py
@@ -6,79 +6,141 @@ import torch
 import matplotlib.pyplot as plt
 
 from spice import SpiceDataset
-from weinhardt2026.studies.hwang2026.benchmarking_hwang2026 import get_dataset, ACTION_NAMES
+from weinhardt2026.studies.hwang2026.benchmarking_hwang2026 import (
+    ACTION_NAMES,
+    DEFAULT_DATA_PATH,
+    GROOMING_ACTION,
+    LOWER_STATUS_HAS_LARGER_RANK_NUMBER,
+)
 
 
-METRIC_LABELS = {
-    'p_action': 'P(Action)',
-    'p_grooming': 'P(Grooming)',
-    'p_gesture': 'P(Gesture)',
-    'p_scratch': 'P(Scratch)',
-    'p_switch': 'P(Switch)',
-    'p_groom_given_partner_groom': 'P(Groom | Partner Groom)',
-    'p_groom_given_partner_action': 'P(Groom | Partner Action)',
-    'p_groom_given_partner_gesture': 'P(Groom | Partner Gesture)',
-    'p_groom_sender_lower': 'P(Groom | Sender Lower Rank)',
-    'p_groom_sender_higher': 'P(Groom | Sender Higher Rank)',
+LOWER_RANK = 'sender_lower_rank'
+HIGHER_RANK = 'sender_higher_rank'
+
+
+def _action_slug(action_name: str) -> str:
+    return action_name.lower().replace(' ', '_')
+
+
+ACTION_FREQUENCY_METRIC_LABELS = {
+    f'p_{_action_slug(action_name)}': f'P({action_name.title()})'
+    for action_name in ACTION_NAMES.values()
 }
 
+OVERVIEW_METRIC_LABELS = {
+    **ACTION_FREQUENCY_METRIC_LABELS,
+    'p_switch': 'P(Switch)',
+    'p_groom_sender_lower_rank': 'P(Next Groom | Sender Lower Rank)',
+    'p_groom_sender_higher_rank': 'P(Next Groom | Sender Higher Rank)',
+}
 
-def _get_rank_mapping() -> dict[int, int]:
-    """Load ape ID → dominance rank mapping from the original CSV."""
-    path_data = 'weinhardt2026/studies/hwang2026/data/hwang2025_processed.csv'
+CONDITIONAL_METRIC_LABELS = {}
+for action_name in ACTION_NAMES.values():
+    slug = _action_slug(action_name)
+    label = action_name.title()
+    CONDITIONAL_METRIC_LABELS[f'p_groom_given_partner_{slug}'] = (
+        f'P(Next Groom | Partner {label})'
+    )
+    CONDITIONAL_METRIC_LABELS[f'p_groom_given_partner_{slug}_sender_lower_rank'] = (
+        f'P(Next Groom | Partner {label}, Sender Lower Rank)'
+    )
+    CONDITIONAL_METRIC_LABELS[f'p_groom_given_partner_{slug}_sender_higher_rank'] = (
+        f'P(Next Groom | Partner {label}, Sender Higher Rank)'
+    )
+
+METRIC_LABELS = {
+    **OVERVIEW_METRIC_LABELS,
+    **CONDITIONAL_METRIC_LABELS,
+}
+OVERVIEW_METRICS = list(OVERVIEW_METRIC_LABELS.keys())
+CONDITIONAL_METRICS = list(CONDITIONAL_METRIC_LABELS.keys())
+
+
+def _get_rank_mapping(path_data: str = DEFAULT_DATA_PATH) -> dict[int, int]:
+    """Load ape ID -> dominance-rank mapping from the original CSV."""
+    if path_data is None or not os.path.exists(path_data):
+        return {}
+
     df = pd.read_csv(path_data)
-    # Build mapping from both ID1 and ID2 columns
     rank_map = {}
-    for _, row in df[['ID1', 'Dominance rank_ID1']].drop_duplicates().iterrows():
-        rank_map[int(row['ID1'])] = int(row['Dominance rank_ID1'])
-    for _, row in df[['ID2', 'Dominance rank_ID2']].drop_duplicates().iterrows():
-        rank_map[int(row['ID2'])] = int(row['Dominance rank_ID2'])
+    if {'ID1', 'Dominance rank_ID1'}.issubset(df.columns):
+        for _, row in df[['ID1', 'Dominance rank_ID1']].dropna().drop_duplicates().iterrows():
+            rank_map[int(row['ID1'])] = int(row['Dominance rank_ID1'])
+    if {'ID2', 'Dominance rank_ID2'}.issubset(df.columns):
+        for _, row in df[['ID2', 'Dominance rank_ID2']].dropna().drop_duplicates().iterrows():
+            rank_map[int(row['ID2'])] = int(row['Dominance rank_ID2'])
     return rank_map
 
 
 def _extract_data(dataset: SpiceDataset):
-    """Extract choices and partner actions from a hwang2026 dataset.
+    """Extract choices, partner actions, and per-trial sender/receiver IDs.
 
-    Feature layout (n_actions=4, no reward columns):
-        [action_oh(4), SigAct_ID2, ID1, ID2, time_trial, trials, block, experiment_id, participant_id]
+    Feature layout for the current Hwang setup is:
+        [action_oh(4), SigAct_ID2, ID1, ID2, time_trial, trial, block, experiment_id, participant_id]
+
+    SPICE datasets store model inputs in xs and response targets in ys. For this
+    analysis the focal behavior is the response action, so choices must be read
+    from ys while partner-action conditions and IDs come from xs.
 
     Returns:
-        choices: (n_sessions, n_trials) int — action category index (0-3), NaN for padded.
-        partner_actions: (n_sessions, n_trials) int — partner's action category, NaN for padded.
-        id1s: (n_sessions,) int — sender ID per session.
-        id2s: (n_sessions,) int — receiver ID per session.
+        choices: (n_sessions, n_trials) float, action index or NaN for padding.
+        partner_actions: (n_sessions, n_trials) float, partner action or NaN.
+        sender_ids: (n_sessions, n_trials) float, current ID1/sender or NaN.
+        receiver_ids: (n_sessions, n_trials) float, current ID2/receiver or NaN.
     """
     n_actions = dataset.n_actions
-    xs = dataset.xs[:, :, 0, :]  # (sessions, trials, features)
+    xs = dataset.xs.detach().cpu()[:, :, 0, :]
+    ys = dataset.ys.detach().cpu()[:, :, 0, :]
 
-    valid = ~torch.isnan(xs[:, :, 0])
+    valid = (~torch.isnan(xs[:, :, 0])) & (~torch.isnan(ys[:, :, 0]))
+    valid_np = valid.numpy()
 
-    choices = xs[:, :, :n_actions].nan_to_num(0).argmax(dim=-1).float().numpy()
-    partner_actions = xs[:, :, n_actions].numpy()  # SigAct_ID2
+    choices = ys[:, :, :n_actions].nan_to_num(0).argmax(dim=-1).float().numpy()
+    partner_actions = xs[:, :, n_actions].float().numpy()
+    sender_ids = xs[:, :, -1].float().numpy()
+    receiver_ids = xs[:, :, -2].float().numpy()
 
-    choices[~valid.numpy()] = np.nan
-    partner_actions[~valid.numpy()] = np.nan
+    choices[~valid_np] = np.nan
+    partner_actions[~valid_np] = np.nan
+    sender_ids[~valid_np] = np.nan
+    receiver_ids[~valid_np] = np.nan
 
-    id1s = xs[:, 0, -1].nan_to_num(0).long().numpy()
-    id2s = xs[:, 0, -2].nan_to_num(0).long().numpy()
-
-    return choices, partner_actions, id1s, id2s
+    return choices, partner_actions, sender_ids, receiver_ids
 
 
-def _compute_metrics(choices, partner_actions, id1s, id2s, rank_map=None):
-    """Compute per-session behavioral metrics for chimpanzee communication.
+def _rank_relation(sender_id: float, receiver_id: float, rank_map: dict[int, int]) -> str | None:
+    """Return rank relation for a generated/real directed row.
 
-    Args:
-        choices: (n_sessions, n_trials) float — sender's action (0-3), NaN for padded.
-        partner_actions: (n_sessions, n_trials) float — partner's action, NaN for padded.
-        id1s: (n_sessions,) int — sender IDs.
-        id2s: (n_sessions,) int — receiver IDs.
-        rank_map: dict mapping ape ID → dominance rank (optional).
-
-    Returns:
-        dict mapping metric name → (n_sessions,) numpy array.
+    The rank-number convention is controlled by LOWER_STATUS_HAS_LARGER_RANK_NUMBER.
     """
+    if np.isnan(sender_id) or np.isnan(receiver_id):
+        return None
+
+    sender_rank = rank_map.get(int(sender_id))
+    receiver_rank = rank_map.get(int(receiver_id))
+    if sender_rank is None or receiver_rank is None or sender_rank == receiver_rank:
+        return None
+    if LOWER_STATUS_HAS_LARGER_RANK_NUMBER:
+        return LOWER_RANK if sender_rank > receiver_rank else HIGHER_RANK
+    return LOWER_RANK if sender_rank < receiver_rank else HIGHER_RANK
+
+
+def _relation_mask(
+    sender_ids: np.ndarray,
+    receiver_ids: np.ndarray,
+    rank_map: dict[int, int],
+    relation: str,
+) -> np.ndarray:
+    mask = np.zeros(sender_ids.shape, dtype=bool)
+    for idx, (sender_id, receiver_id) in enumerate(zip(sender_ids, receiver_ids)):
+        mask[idx] = _rank_relation(sender_id, receiver_id, rank_map) == relation
+    return mask
+
+
+def _compute_metrics(choices, partner_actions, sender_ids, receiver_ids, rank_map=None):
+    """Compute per-session behavioral metrics for chimpanzee communication."""
     n_sessions = choices.shape[0]
+    rank_map = rank_map or {}
 
     metrics = {k: np.full(n_sessions, np.nan) for k in METRIC_LABELS}
 
@@ -86,92 +148,108 @@ def _compute_metrics(choices, partner_actions, id1s, id2s, rank_map=None):
         valid = ~np.isnan(choices[s])
         ch = choices[s][valid]
         pa = partner_actions[s][valid]
-        pa_valid = ~np.isnan(pa)
+        sid = sender_ids[s][valid]
+        rid = receiver_ids[s][valid]
 
         if len(ch) == 0:
             continue
 
-        # Action frequencies
-        metrics['p_action'][s] = (ch == 0).mean()
-        metrics['p_grooming'][s] = (ch == 1).mean()
-        metrics['p_gesture'][s] = (ch == 2).mean()
-        metrics['p_scratch'][s] = (ch == 3).mean()
+        for action_id, action_name in ACTION_NAMES.items():
+            metrics[f'p_{_action_slug(action_name)}'][s] = (ch == action_id).mean()
 
-        # Switching rate
         if len(ch) > 1:
-            switches = (ch[1:] != ch[:-1])
-            metrics['p_switch'][s] = switches.mean()
+            metrics['p_switch'][s] = (ch[1:] != ch[:-1]).mean()
 
-        # Conditional grooming given partner's action
-        pa_ch = pa[pa_valid]
-        ch_pa = ch[pa_valid]
-        if len(pa_ch) > 0:
-            for act_cat, metric_key in [(1, 'p_groom_given_partner_groom'),
-                                         (0, 'p_groom_given_partner_action'),
-                                         (2, 'p_groom_given_partner_gesture')]:
-                mask = pa_ch == act_cat
-                if mask.sum() > 0:
-                    metrics[metric_key][s] = (ch_pa[mask] == 1).mean()
+        lower_mask = _relation_mask(sid, rid, rank_map, LOWER_RANK)
+        higher_mask = _relation_mask(sid, rid, rank_map, HIGHER_RANK)
 
-        # Rank-conditional grooming
-        if rank_map is not None:
-            id1, id2 = int(id1s[s]), int(id2s[s])
-            rank1 = rank_map.get(id1)
-            rank2 = rank_map.get(id2)
-            if rank1 is not None and rank2 is not None:
-                groom_rate = (ch == 1).mean()
-                if rank1 < rank2:
-                    metrics['p_groom_sender_lower'][s] = groom_rate
-                elif rank1 > rank2:
-                    metrics['p_groom_sender_higher'][s] = groom_rate
+        if lower_mask.sum() > 0:
+            metrics['p_groom_sender_lower_rank'][s] = (ch[lower_mask] == GROOMING_ACTION).mean()
+        if higher_mask.sum() > 0:
+            metrics['p_groom_sender_higher_rank'][s] = (ch[higher_mask] == GROOMING_ACTION).mean()
+
+        pa_valid = ~np.isnan(pa)
+        for action_id, action_name in ACTION_NAMES.items():
+            slug = _action_slug(action_name)
+            action_mask = pa_valid & (pa == action_id)
+            if action_mask.sum() > 0:
+                metrics[f'p_groom_given_partner_{slug}'][s] = (
+                    ch[action_mask] == GROOMING_ACTION
+                ).mean()
+
+            lower_action_mask = action_mask & lower_mask
+            if lower_action_mask.sum() > 0:
+                metrics[f'p_groom_given_partner_{slug}_sender_lower_rank'][s] = (
+                    ch[lower_action_mask] == GROOMING_ACTION
+                ).mean()
+
+            higher_action_mask = action_mask & higher_mask
+            if higher_action_mask.sum() > 0:
+                metrics[f'p_groom_given_partner_{slug}_sender_higher_rank'][s] = (
+                    ch[higher_action_mask] == GROOMING_ACTION
+                ).mean()
 
     return metrics
 
 
-def _plot_violins(all_metrics, output_dir):
+def _plot_violins(all_metrics, output_dir, metric_names, filename):
     """Create violin plots comparing behavioral metrics across datasets."""
     model_names = list(all_metrics.keys())
-    metric_names = list(METRIC_LABELS.keys())
-    colors = plt.cm.tab10.colors[:len(model_names)]
+    if not model_names or not metric_names:
+        return
 
+    colors = plt.cm.tab10.colors
     n_metrics = len(metric_names)
     n_cols = 3
     n_rows = (n_metrics + n_cols - 1) // n_cols
     fig, axes = plt.subplots(n_rows, n_cols, figsize=(14, 4 * n_rows))
-    axes = axes.flatten()
+    axes = np.atleast_1d(axes).flatten()
 
     for i, metric in enumerate(metric_names):
         ax = axes[i]
-        data = []
-        for model_name in model_names:
+        plot_data = []
+        plot_positions = []
+        plot_model_indices = []
+        for model_idx, model_name in enumerate(model_names):
             values = all_metrics[model_name][metric]
-            data.append(values[~np.isnan(values)])
+            values = values[~np.isnan(values)]
+            if len(values) == 0:
+                continue
+            plot_data.append(values)
+            plot_positions.append(model_idx + 1)
+            plot_model_indices.append(model_idx)
 
-        if all(len(d) == 0 for d in data):
+        if not plot_data:
             ax.set_visible(False)
             continue
 
-        parts = ax.violinplot(data, showmeans=True, showmedians=True, showextrema=False)
+        parts = ax.violinplot(
+            plot_data,
+            positions=plot_positions,
+            showmeans=True,
+            showmedians=True,
+            showextrema=False,
+        )
 
-        for j, body in enumerate(parts['bodies']):
-            body.set_facecolor(colors[j])
+        for body, model_idx in zip(parts['bodies'], plot_model_indices):
+            body.set_facecolor(colors[model_idx % len(colors)])
             body.set_alpha(0.7)
         parts['cmeans'].set_color('black')
         parts['cmedians'].set_color('gray')
         parts['cmedians'].set_linestyle('--')
 
         ax.set_xticks(range(1, len(model_names) + 1))
-        ax.set_xticklabels(model_names, fontsize=9)
+        ax.set_xticklabels(model_names, fontsize=9, rotation=20, ha='right')
         ax.set_title(METRIC_LABELS[metric], fontsize=11)
+        ax.set_ylim(-0.05, 1.05)
         ax.grid(axis='y', alpha=0.3)
 
     for i in range(n_metrics, len(axes)):
         axes[i].set_visible(False)
 
     fig.tight_layout()
-    fig.savefig(os.path.join(output_dir, 'generative_behavior.pdf'), bbox_inches='tight', dpi=150)
-    fig.savefig(os.path.join(output_dir, 'generative_behavior.png'), bbox_inches='tight', dpi=150)
-    plt.show()
+    fig.savefig(os.path.join(output_dir, f'{filename}.pdf'), bbox_inches='tight', dpi=150)
+    fig.savefig(os.path.join(output_dir, f'{filename}.png'), bbox_inches='tight', dpi=150)
     plt.close(fig)
 
 
@@ -182,21 +260,11 @@ def analysis_generative_behavior(
     dataset_spice: SpiceDataset = None,
     output_dir: str = 'results',
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Run generative behavior analysis for the hwang2026 chimpanzee communication task.
+    """Run generative behavior analysis for the Hwang chimpanzee task.
 
-    Computes behavioral metrics (action frequencies, switching rates,
-    grooming contingencies, rank-conditional grooming) and produces violin plots.
-
-    Args:
-        dataset_real: Real behavioral SpiceDataset.
-        dataset_gru: GRU-generated SpiceDataset.
-        dataset_spice_rnn: SPICE-RNN generated SpiceDataset.
-        dataset_spice: SPICE equation-generated SpiceDataset.
-        output_dir: Directory for output plots.
-
-    Returns:
-        df_summary: DataFrame with mean +/- std per metric per model.
-        df_comparison: DataFrame with NMAE per metric (if real data provided).
+    Computes action frequencies plus task-specific conditional grooming metrics:
+    P(Grooming | partner action category) and the same quantities split by
+    sender/receiver dominance-rank relation.
     """
     os.makedirs(output_dir, exist_ok=True)
 
@@ -210,15 +278,20 @@ def analysis_generative_behavior(
     if dataset_spice_rnn is not None:
         datasets['spice_rnn'] = dataset_spice_rnn
     if dataset_spice is not None:
-        datasets['spice'] = dataset_spice
+        datasets['spice_sym'] = dataset_spice
 
     all_metrics = {}
     for name, ds in datasets.items():
         print(f"Computing metrics for {name}...")
-        choices, partner_actions, id1s, id2s = _extract_data(ds)
-        all_metrics[name] = _compute_metrics(choices, partner_actions, id1s, id2s, rank_map)
+        choices, partner_actions, sender_ids, receiver_ids = _extract_data(ds)
+        all_metrics[name] = _compute_metrics(
+            choices,
+            partner_actions,
+            sender_ids,
+            receiver_ids,
+            rank_map,
+        )
 
-    # Summary table
     rows = []
     for name in all_metrics:
         row = {'Model': name}
@@ -233,10 +306,16 @@ def analysis_generative_behavior(
 
     df_summary = pd.DataFrame(rows).set_index('Model')
     print(df_summary)
+    df_summary.to_csv(os.path.join(output_dir, 'generative_behavior_summary.csv'))
 
-    _plot_violins(all_metrics, output_dir)
+    _plot_violins(all_metrics, output_dir, OVERVIEW_METRICS, 'generative_behavior')
+    _plot_violins(
+        all_metrics,
+        output_dir,
+        CONDITIONAL_METRICS,
+        'generative_behavior_conditional_grooming',
+    )
 
-    # Quantitative comparison: normalised MAE vs real data
     df_comparison = None
     if 'real' in all_metrics:
         real_means = {}
@@ -272,5 +351,6 @@ def analysis_generative_behavior(
         df_comparison = pd.DataFrame(comp_rows).set_index('Model')
         print("\nNormalized MAE (|model_mean - real_mean| / real_std):")
         print(df_comparison)
+        df_comparison.to_csv(os.path.join(output_dir, 'generative_behavior_nmae.csv'))
 
     return df_summary, df_comparison

--- a/weinhardt2026/studies/hwang2026/benchmarking_hwang2026.py
+++ b/weinhardt2026/studies/hwang2026/benchmarking_hwang2026.py
@@ -1,3 +1,4 @@
+import os
 import torch
 import pandas as pd
 import numpy as np
@@ -11,8 +12,12 @@ from weinhardt2026.studies.hwang2026.spice_hwang2026 import CONFIG
 
 # --- Constants ---
 
+DEFAULT_DATA_PATH = 'weinhardt2026/studies/hwang2026/data/hwang2025_processed.csv'
 N_ACTIONS = 4  # TODO: set to 5 when working with scratching data
 N_TRIALS_DEFAULT = 20
+WAITING_ACTION = 3
+GROOMING_ACTION = 1
+LOWER_STATUS_HAS_LARGER_RANK_NUMBER = True
 # TODO: replace when working with scratching data
 # ACTION_NAMES = {0: 'action', 1: 'grooming', 2: 'gesture', 3: 'scratching', 4: 'waiting'}
 ACTION_NAMES = {0: 'action', 1: 'grooming', 2: 'gesture', 3: 'waiting'}
@@ -26,7 +31,7 @@ def get_dataset(
 ) -> tuple[SpiceDataset, SpiceDataset, dict]:
 
     if path_data is None:
-        path_data = 'weinhardt2026/studies/hwang2026/data/hwang2025_processed.csv'
+        path_data = DEFAULT_DATA_PATH
 
     dataset = csv_to_dataset(
         file=path_data,
@@ -38,11 +43,11 @@ def get_dataset(
 
     n_actions = dataset.n_actions
 
-    # Remap participant_id → ID1, experiment_id → ID2
+    # Remap participant_id -> ID1, experiment_id -> ID2
     dataset.xs[..., -1] = dataset.xs[..., n_actions + 1].nan_to_num(0)
     dataset.xs[..., -2] = dataset.xs[..., n_actions + 2].nan_to_num(0)
 
-    n_participants = dataset.xs[:, 0, -1].nan_to_num(0).max().int().item() + 1
+    n_participants = dataset.xs[..., [-1, -2]].nan_to_num(0).max().int().item() + 1
 
     if test_blocks is None:
         test_blocks = (1,)
@@ -65,18 +70,69 @@ def get_pair_table(dataset: SpiceDataset) -> pd.DataFrame:
     Returns a DataFrame with columns: id1, id2, rank1, rank2, sender_lower_rank.
     """
     # Read raw CSV to get dominance ranks
-    path_data = 'weinhardt2026/studies/hwang2026/data/hwang2025_processed.csv'
-    df = pd.read_csv(path_data)
+    df = pd.read_csv(DEFAULT_DATA_PATH)
     pairs = df.groupby(['ID1', 'ID2']).agg({
         'Dominance rank_ID1': 'first',
         'Dominance rank_ID2': 'first',
     }).reset_index()
     pairs.columns = ['id1', 'id2', 'rank1', 'rank2']
-    pairs['sender_lower_rank'] = pairs['rank1'] < pairs['rank2']
+    if LOWER_STATUS_HAS_LARGER_RANK_NUMBER:
+        pairs['sender_lower_rank'] = pairs['rank1'] > pairs['rank2']
+    else:
+        pairs['sender_lower_rank'] = pairs['rank1'] < pairs['rank2']
     return pairs
 
 
 # --- Dyadic Behavior Generation ---
+
+def _load_empirical_metadata(path_data: str = DEFAULT_DATA_PATH) -> tuple[dict[int, int], dict[tuple[int, int], dict]]:
+    """Load rank and pair-level metadata used when writing generated CSV files."""
+    if path_data is None or not os.path.exists(path_data):
+        return {}, {}
+
+    df = pd.read_csv(path_data)
+    rank_map = {}
+    pair_metadata = {}
+
+    for id_col, rank_col in (
+        ('ID1', 'Dominance rank_ID1'),
+        ('ID2', 'Dominance rank_ID2'),
+    ):
+        if id_col not in df.columns or rank_col not in df.columns:
+            continue
+        for _, row in df[[id_col, rank_col]].dropna().drop_duplicates().iterrows():
+            rank_map[int(row[id_col])] = int(row[rank_col])
+
+    required_pair_cols = {'ID1', 'ID2'}
+    if required_pair_cols.issubset(df.columns):
+        for _, row in df.drop_duplicates(['ID1', 'ID2']).iterrows():
+            pair = (int(row['ID1']), int(row['ID2']))
+            pair_metadata[pair] = {
+                'community_id': int(row['community_id']) if 'community_id' in df.columns else 0,
+            }
+
+    return rank_map, pair_metadata
+
+
+def _extract_session_pairs(dataset: SpiceDataset) -> torch.Tensor:
+    """Return one directed sender/receiver pair per empirical interaction session."""
+    xs = dataset.xs[:, :, 0, :]
+    valid = ~torch.isnan(xs[..., 0])
+    id1 = xs[..., -1].nan_to_num(0).long()
+    id2 = xs[..., -2].nan_to_num(0).long()
+
+    pairs = []
+    for session_idx in range(xs.shape[0]):
+        valid_trials = torch.where(valid[session_idx])[0]
+        if len(valid_trials) == 0:
+            continue
+        first_trial = valid_trials[0]
+        pairs.append(torch.stack([id1[session_idx, first_trial], id2[session_idx, first_trial]]))
+
+    if not pairs:
+        raise ValueError("Cannot generate behavior from an empty dataset.")
+    return torch.stack(pairs, dim=0)
+
 
 @torch.no_grad()
 def generate_behavior(
@@ -84,27 +140,40 @@ def generate_behavior(
     dataset: SpiceDataset,
     n_trials: int = N_TRIALS_DEFAULT,
     save_csv: str = None,
+    source_csv: str = DEFAULT_DATA_PATH,
+    waiting_action: int = WAITING_ACTION,
+    initial_sender_action: int = None,
 ) -> SpiceDataset:
     """Generate synthetic behavior by letting two model instances communicate.
 
-    For each (ID1, ID2) pair in the dataset, two "chimps" alternate turns:
-      - Ape1 (sender=ID1, receiver=ID2) generates an action
-      - Ape2 (sender=ID2, receiver=ID1) responds
-      - They alternate for n_trials total exchanges
+    For each empirical interaction session, two "chimps" with that session
+    directed ID1/ID2 pair alternate turns:
+      - ape1 starts with a random seed action
+      - ape2 observes that seed action and responds
+      - ape1 responds to ape2
+      - this repeats for n_trials generated ape1 responses
 
-    The same model is used for both chimps — the participant/experiment
-    embeddings distinguish them.
+    The same model is used for both chimps; the participant/experiment
+    embeddings distinguish them. The returned dataset records the focal ape1
+    sequence only, so each generated session has fixed ID1/ID2 columns like the
+    empirical interaction_id groups.
 
     Args:
         model: Fitted SPICE model (SpiceEstimator or nn.Module).
         dataset: Original dataset (used to extract ID pairs and metadata).
-        n_trials: Number of exchange trials to generate per pair.
+        n_trials: Number of generated focal-ape responses per interaction session.
         save_csv: Optional path to save generated behavior as CSV.
+        source_csv: Empirical CSV path used for rank/community metadata.
+        waiting_action: Action index used as the receiver's initial previous action.
+        initial_sender_action: Optional fixed seed action for ape1; if None, sampled uniformly.
 
     Returns:
         SpiceDataset with generated dyadic behavior.
     """
     print("Generating dyadic behavior...")
+
+    if dataset.n_reward_features != 0 or dataset.n_additional_inputs < 3:
+        raise ValueError("Hwang generation expects no rewards and additional inputs: SigAct_ID2, ID1, ID2.")
 
     # Unwrap SpiceEstimator
     if isinstance(model, SpiceEstimator):
@@ -123,80 +192,69 @@ def generate_behavior(
     n_actions = dataset.n_actions
     n_features = dataset.xs.shape[-1]
 
-    # Extract unique (ID1, ID2) pairs from the dataset
-    id1_all = dataset.xs[:, 0, 0, -1].nan_to_num(0).long()
-    id2_all = dataset.xs[:, 0, 0, -2].nan_to_num(0).long()
-    pairs = torch.stack([id1_all, id2_all], dim=1).unique(dim=0)
+    pairs = _extract_session_pairs(dataset).to(device)
     n_pairs = pairs.shape[0]
 
-    id1s = pairs[:, 0]  # (n_pairs,)
-    id2s = pairs[:, 1]  # (n_pairs,)
+    id1s = pairs[:, 0]
+    id2s = pairs[:, 1]
 
-    # Storage for generated sequences
     xs_gen = torch.full((n_pairs, n_trials, 1, n_features), float('nan'), device=device)
     ys_gen = torch.full((n_pairs, n_trials, 1, n_actions), float('nan'), device=device)
 
-    # Fill constant metadata columns for all trials
-    xs_gen[:, :, 0, -1] = id1s.unsqueeze(1).expand(-1, n_trials).float()  # participant_id = ID1
-    xs_gen[:, :, 0, -2] = id2s.unsqueeze(1).expand(-1, n_trials).float()  # experiment_id = ID2
-    xs_gen[:, :, 0, -3] = 0  # block
-    xs_gen[:, :, 0, -4] = torch.arange(n_trials, device=device).unsqueeze(0).expand(n_pairs, -1).float()  # trial index
-    xs_gen[:, :, 0, -5] = 0  # time_trial
-    # Additional inputs: ID1 and ID2 columns
-    xs_gen[:, :, 0, n_actions + 1] = id1s.unsqueeze(1).expand(-1, n_trials).float()
-    xs_gen[:, :, 0, n_actions + 2] = id2s.unsqueeze(1).expand(-1, n_trials).float()
-
-    # Hidden states for ape1 (sender=ID1) and ape2 (sender=ID2)
     state_ape1 = None
     state_ape2 = None
 
-    # Initial actions: waiting (scratch) for both
-    action_ape1 = torch.full((n_pairs,), 3, dtype=torch.long, device=device)  # scratch/waiting
-    action_ape2 = torch.randint(0, n_actions, (n_pairs,), device=device)  # random initial from ape2
+    # Initial conditions from the proposal: ape1 has a random seed action;
+    # ape2's own previous action is waiting.
+    if initial_sender_action is None:
+        action_ape1 = torch.randint(0, n_actions, (n_pairs,), device=device)
+    else:
+        action_ape1 = torch.full((n_pairs,), initial_sender_action, dtype=torch.long, device=device)
+    action_ape2 = torch.full((n_pairs,), waiting_action, dtype=torch.long, device=device)
 
     for t in tqdm(range(n_trials)):
-        if t % 2 == 0:
-            # Ape1's turn: ape1 is sender, ape2 is receiver
-            # Build observation for ape1: its own last action + ape2's last action as SigAct_ID2
-            obs = _build_observation(
-                own_action=action_ape1,
-                partner_action=action_ape2,
-                sender_id=id1s,
-                receiver_id=id2s,
-                trial_idx=t,
-                n_actions=n_actions,
-                n_features=n_features,
-                device=device,
-            )
+        # Ape2 responds to ape1's previous action. This closes the dyadic loop
+        # but is not written as a separate empirical-style focal sequence row.
+        obs_ape2 = _build_observation(
+            own_action=action_ape2,
+            partner_action=action_ape1,
+            sender_id=id2s,
+            receiver_id=id1s,
+            trial_idx=t,
+            n_actions=n_actions,
+            n_features=n_features,
+            device=device,
+        )
+        logits_ape2, state_ape2 = inner_model(obs_ape2, state_ape2)
+        action_ape2 = _sample_action(logits_ape2, n_actions)
 
-            logits, state_ape1 = inner_model(obs, state_ape1)
-            action_ape1 = _sample_action(logits, n_actions)
+        # Ape1 responds to ape2. This is the generated focal behavior that is
+        # compared with empirical ID1 behavior.
+        own_action_ape1 = action_ape1
+        obs_ape1 = _build_observation(
+            own_action=own_action_ape1,
+            partner_action=action_ape2,
+            sender_id=id1s,
+            receiver_id=id2s,
+            trial_idx=t,
+            n_actions=n_actions,
+            n_features=n_features,
+            device=device,
+        )
+        logits_ape1, state_ape1 = inner_model(obs_ape1, state_ape1)
+        action_ape1 = _sample_action(logits_ape1, n_actions)
 
-            # Record in dataset (from ape1's perspective)
-            xs_gen[:, t, 0, :n_actions] = torch.nn.functional.one_hot(action_ape1, n_actions).float()
-            xs_gen[:, t, 0, n_actions] = action_ape2.float()  # SigAct_ID2
-            ys_gen[:, t, 0, :] = torch.nn.functional.one_hot(action_ape1, n_actions).float()
-        else:
-            # Ape2's turn: ape2 is sender, ape1 is receiver
-            # FLIP: sender=ID2, receiver=ID1
-            obs = _build_observation(
-                own_action=action_ape2,
-                partner_action=action_ape1,
-                sender_id=id2s,
-                receiver_id=id1s,
-                trial_idx=t,
-                n_actions=n_actions,
-                n_features=n_features,
-                device=device,
-            )
-
-            logits, state_ape2 = inner_model(obs, state_ape2)
-            action_ape2 = _sample_action(logits, n_actions)
-
-            # Record in dataset (from ape1's perspective for consistency)
-            xs_gen[:, t, 0, :n_actions] = torch.nn.functional.one_hot(action_ape1, n_actions).float()
-            xs_gen[:, t, 0, n_actions] = action_ape2.float()  # SigAct_ID2
-            ys_gen[:, t, 0, :] = torch.nn.functional.one_hot(action_ape2, n_actions).float()
+        _write_generated_step(
+            xs_gen=xs_gen,
+            ys_gen=ys_gen,
+            trial_idx=t,
+            own_action=own_action_ape1,
+            generated_action=action_ape1,
+            partner_action=action_ape2,
+            sender_id=id1s,
+            receiver_id=id2s,
+            n_actions=n_actions,
+        )
 
     xs_gen = xs_gen.cpu()
     ys_gen = ys_gen.cpu()
@@ -204,10 +262,40 @@ def generate_behavior(
     dataset_gen = SpiceDataset(xs_gen, ys_gen, n_reward_features=0)
 
     if save_csv is not None:
-        _save_generated_csv(dataset_gen, save_csv)
+        _save_generated_csv(dataset_gen, save_csv, source_csv=source_csv)
 
     print("Done generating dyadic behavior.")
     return dataset_gen
+
+
+def _write_generated_step(
+    xs_gen: torch.Tensor,
+    ys_gen: torch.Tensor,
+    trial_idx: int,
+    own_action: torch.Tensor,
+    generated_action: torch.Tensor,
+    partner_action: torch.Tensor,
+    sender_id: torch.Tensor,
+    receiver_id: torch.Tensor,
+    n_actions: int,
+) -> None:
+    """Write one generated response and the model input that produced it."""
+    xs_gen[:, trial_idx, 0, :n_actions] = torch.nn.functional.one_hot(
+        own_action, n_actions,
+    ).float()
+    xs_gen[:, trial_idx, 0, n_actions] = partner_action.float()  # SigAct_ID2
+    xs_gen[:, trial_idx, 0, n_actions + 1] = sender_id.float()   # ID1
+    xs_gen[:, trial_idx, 0, n_actions + 2] = receiver_id.float() # ID2
+
+    xs_gen[:, trial_idx, 0, -5] = 0
+    xs_gen[:, trial_idx, 0, -4] = float(trial_idx)
+    xs_gen[:, trial_idx, 0, -3] = 0
+    xs_gen[:, trial_idx, 0, -2] = receiver_id.float()
+    xs_gen[:, trial_idx, 0, -1] = sender_id.float()
+
+    ys_gen[:, trial_idx, 0, :] = torch.nn.functional.one_hot(
+        generated_action, n_actions,
+    ).float()
 
 
 def _build_observation(
@@ -223,13 +311,13 @@ def _build_observation(
     """Build a single-trial observation tensor for the model.
 
     Args:
-        own_action: (n_pairs,) int — sender's last action.
-        partner_action: (n_pairs,) int — receiver's last action.
-        sender_id: (n_pairs,) int — sender ape ID (= participant_id).
-        receiver_id: (n_pairs,) int — receiver ape ID (= experiment_id).
-        trial_idx: int — current trial index.
-        n_actions: int — number of action categories.
-        n_features: int — total feature dimension.
+        own_action: (n_pairs,) int - focal ape's previous action.
+        partner_action: (n_pairs,) int - partner ape's previous action.
+        sender_id: (n_pairs,) int - focal ape ID (= participant_id).
+        receiver_id: (n_pairs,) int - partner ape ID (= experiment_id).
+        trial_idx: int - current trial index.
+        n_actions: int - number of action categories.
+        n_features: int - total feature dimension.
         device: torch device.
 
     Returns:
@@ -238,19 +326,15 @@ def _build_observation(
     n_pairs = own_action.shape[0]
     obs = torch.zeros(n_pairs, 1, 1, n_features, device=device)
 
-    # Own action (one-hot)
     obs[:, 0, 0, :n_actions] = torch.nn.functional.one_hot(own_action, n_actions).float()
-    # Partner's action as SigAct_ID2 (integer)
     obs[:, 0, 0, n_actions] = partner_action.float()
-    # ID1 (sender) and ID2 (receiver) in additional inputs
     obs[:, 0, 0, n_actions + 1] = sender_id.float()
     obs[:, 0, 0, n_actions + 2] = receiver_id.float()
-    # Metadata
-    obs[:, 0, 0, -5] = 0  # time_trial
-    obs[:, 0, 0, -4] = float(trial_idx)  # trial index
-    obs[:, 0, 0, -3] = 0  # block
-    obs[:, 0, 0, -2] = receiver_id.float()  # experiment_id = receiver
-    obs[:, 0, 0, -1] = sender_id.float()  # participant_id = sender
+    obs[:, 0, 0, -5] = 0
+    obs[:, 0, 0, -4] = float(trial_idx)
+    obs[:, 0, 0, -3] = 0
+    obs[:, 0, 0, -2] = receiver_id.float()
+    obs[:, 0, 0, -1] = sender_id.float()
 
     return obs
 
@@ -266,7 +350,7 @@ def _sample_action(logits: torch.Tensor, n_actions: int) -> torch.Tensor:
         action_idx: (B,) sampled action indices.
     """
     if logits.dim() == 5:  # BaseModel: (E, B, T, W, A)
-        logits = logits.mean(dim=0)  # ensemble mean
+        logits = logits.mean(dim=0)
     if logits.dim() == 4:  # (B, T, W, A)
         logits_t = logits[:, -1, 0, :n_actions]
     else:  # (B, T, A)
@@ -276,25 +360,84 @@ def _sample_action(logits: torch.Tensor, n_actions: int) -> torch.Tensor:
     return torch.multinomial(probs, 1).squeeze(-1)
 
 
-def _save_generated_csv(dataset: SpiceDataset, path: str) -> None:
+def _save_generated_csv(
+    dataset: SpiceDataset,
+    path: str,
+    source_csv: str = DEFAULT_DATA_PATH,
+) -> None:
     """Save generated dataset to CSV matching the original data format."""
+    output_dir = os.path.dirname(path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    rank_map, pair_metadata = _load_empirical_metadata(source_csv)
     xs = dataset.xs.numpy()
     ys = dataset.ys.numpy()
     n_actions = dataset.n_actions
     n_sessions = xs.shape[0]
 
+    def append_row(
+        session_idx: int,
+        row_idx: int,
+        id1: int,
+        id2: int,
+        sigact_id1: int,
+        sigact_id2: int,
+        block: int,
+    ) -> None:
+        meta = (
+            pair_metadata.get((id1, id2))
+            or pair_metadata.get((id2, id1))
+            or {}
+        )
+        rows.append({
+            'start': row_idx,
+            'stop': row_idx + 1,
+            'ID1': id1,
+            'ID2': id2,
+            'Dominance rank_ID1': rank_map.get(id1, np.nan),
+            'Dominance rank_ID2': rank_map.get(id2, np.nan),
+            'SigAct_ID1': sigact_id1,
+            'SigAct_ID2': sigact_id2,
+            'interaction_id': session_idx,
+            'community_id': meta.get('community_id', 0),
+            'Grooming_ID1': int(sigact_id1 == GROOMING_ACTION),
+            'Grooming_ID2': int(sigact_id2 == GROOMING_ACTION),
+            'block': block,
+        })
+
     rows = []
     for s in range(n_sessions):
         n_valid = int((~np.isnan(xs[s, :, 0, 0])).sum())
-        for t in range(n_valid):
-            sigact_id1 = int(xs[s, t, 0, :n_actions].argmax())
-            rows.append({
-                'ID1': int(xs[s, t, 0, -1]),
-                'ID2': int(xs[s, t, 0, -2]),
-                'SigAct_ID1': sigact_id1,
-                'SigAct_ID2': int(xs[s, t, 0, n_actions]),
-                'interaction_id': s,
-                'block': int(xs[s, t, 0, -3]),
-            })
+        if n_valid == 0:
+            continue
 
-    pd.DataFrame(rows).to_csv(path, index=False)
+        for t in range(n_valid):
+            append_row(
+                session_idx=s,
+                row_idx=t,
+                id1=int(xs[s, t, 0, -1]),
+                id2=int(xs[s, t, 0, -2]),
+                sigact_id1=int(xs[s, t, 0, :n_actions].argmax()),
+                sigact_id2=int(xs[s, t, 0, n_actions]),
+                block=int(xs[s, t, 0, -3]),
+            )
+
+        last_t = n_valid - 1
+        append_row(
+            session_idx=s,
+            row_idx=n_valid,
+            id1=int(xs[s, last_t, 0, -1]),
+            id2=int(xs[s, last_t, 0, -2]),
+            sigact_id1=int(ys[s, last_t, 0, :n_actions].argmax()),
+            sigact_id2=int(xs[s, last_t, 0, n_actions]),
+            block=int(xs[s, last_t, 0, -3]),
+        )
+
+    columns = [
+        'start', 'stop', 'ID1', 'ID2',
+        'Dominance rank_ID1', 'Dominance rank_ID2',
+        'SigAct_ID1', 'SigAct_ID2', 'interaction_id', 'community_id',
+        'Grooming_ID1', 'Grooming_ID2', 'block',
+    ]
+    pd.DataFrame(rows, columns=columns).to_csv(path, index=False)

--- a/weinhardt2026/studies/hwang2026/hwang2026.py
+++ b/weinhardt2026/studies/hwang2026/hwang2026.py
@@ -1,37 +1,63 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+
 import torch
 
 from spice import SpiceEstimator, csv_to_dataset, split_data_along_blockdim
 from spice_hwang2026 import CONFIG, SpiceModel, cross_entropy_loss_mask_waiting
 
-import sys
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[3]))
 from weinhardt2026.utils.benchmarking_gru import GRUModel, training
 from weinhardt2026.analysis.analysis_model_evaluation import analysis_model_evaluation
 
 
-train_spice = False
-train_gru = False
+# Set to False to reuse saved params instead of retraining.
+RUN_FROM_SCRATCH = True
+train_spice = RUN_FROM_SCRATCH
+train_gru = RUN_FROM_SCRATCH
+
+# Practical full-pipeline settings. Increase SPICE_ENSEMBLE_SIZE for final runs.
+SPICE_EPOCHS = 1000
+GRU_EPOCHS = 1000
+SPICE_ENSEMBLE_SIZE = 1
+SINDY_WEIGHT = 0.01
+N_GENERATED_TRIALS = 20
+
+# -------------------------------------------------------------------------------------------
+# PATHS
+# -------------------------------------------------------------------------------------------
+
+path_data = 'weinhardt2026/studies/hwang2026/data/hwang2025_processed.csv'
+path_spice = 'weinhardt2026/studies/hwang2026/params/spice_hwang2026.pkl'
+path_gru = 'weinhardt2026/studies/hwang2026/params/gru_hwang2026.pkl'
+output_dir = 'weinhardt2026/studies/hwang2026/data'
+results_dir = 'weinhardt2026/studies/hwang2026/results'
+
+for path in (path_spice, path_gru):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+Path(output_dir).mkdir(parents=True, exist_ok=True)
+Path(results_dir).mkdir(parents=True, exist_ok=True)
 
 # -------------------------------------------------------------------------------------------
 # DATALOADER
 # -------------------------------------------------------------------------------------------
 
-path_data = 'weinhardt2026/studies/hwang2026/data/hwang2025_processed.csv'
 dataset = csv_to_dataset(
-    file = path_data,
+    file=path_data,
     df_participant_id='interaction_id',
     df_choice='SigAct_ID1',
     df_feedback=None,
     additional_inputs=['SigAct_ID2', 'ID1', 'ID2'],
-    )
+)
 
-# replace participant id and experiment id columns in dataset with ID1 and ID2 columns from additional inputs
+# Replace participant id and experiment id columns in dataset with ID1 and ID2 columns.
 # participant id -> ID1
 # experiment id -> ID2
-dataset.xs[..., -1] = dataset.xs[..., dataset.n_actions+1].nan_to_num(0)
-dataset.xs[..., -2] = dataset.xs[..., dataset.n_actions+2].nan_to_num(0)
-n_participants = dataset.xs[:, 0, -1].nan_to_num(0).max().int().item()+1
+dataset.xs[..., -1] = dataset.xs[..., dataset.n_actions + 1].nan_to_num(0)
+dataset.xs[..., -2] = dataset.xs[..., dataset.n_actions + 2].nan_to_num(0)
+n_participants = dataset.xs[..., [-1, -2]].nan_to_num(0).max().int().item() + 1
 
 test_blocks = (1,)
 dataset_train, dataset_test = split_data_along_blockdim(dataset=dataset, test_blocks=test_blocks)
@@ -41,28 +67,24 @@ dataset_train, dataset_test = split_data_along_blockdim(dataset=dataset, test_bl
 # SPICE ESTIMATOR
 # -------------------------------------------------------------------------------------------
 
-path_spice = 'weinhardt2026/studies/hwang2026/params/spice_hwang2026.pkl'
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 estimator = SpiceEstimator(
     spice_config=CONFIG,
     spice_class=SpiceModel,
     n_actions=dataset_train.n_actions,
-    n_participants=dataset_train.n_participants,
-    n_experiments=dataset_train.n_experiments,
+    n_participants=n_participants,
+    n_experiments=n_participants,
     n_reward_features=dataset_train.n_reward_features,
     embedding_size=4,
-    
     loss_fn=cross_entropy_loss_mask_waiting,
-    
-    epochs=1,
+    epochs=SPICE_EPOCHS,
     warmup_steps=500,
-    ensemble_size=1,    # fast: 1; default: 10
-    sindy_weight=0,     # fast: 0; default: 0.01
-    
+    ensemble_size=SPICE_ENSEMBLE_SIZE,
+    sindy_weight=SINDY_WEIGHT,
     device=device,
     verbose=True,
-    compiled_forward=False  # set True for better debugging
+    compiled_forward=False,
 )
 
 if train_spice:
@@ -75,43 +97,40 @@ if train_spice:
     estimator.save_spice(path_spice)
 else:
     estimator.load_spice(path_spice)
-    
+
 
 # -------------------------------------------------------------------------------------------
 # GRU FOR BENCHMARKING
 # -------------------------------------------------------------------------------------------
 
-path_gru = path_spice.replace('spice', 'gru')
-
 gru = GRUModel(
-    n_actions=dataset_train.n_actions, 
-    additional_inputs=dataset_train.n_additional_inputs, 
+    n_actions=dataset_train.n_actions,
+    additional_inputs=dataset_train.n_additional_inputs,
     n_reward_features=0,
     # for using vanilla GRU -> set both to 1 (not using participant embeddings)
     n_participants=n_participants,  # to set sender
     n_experiments=n_participants,   # to set receiver; each receiver is basically an experimental condition
-    )
+)
 
 if train_gru:
     optimizer = torch.optim.Adam(gru.parameters(), lr=0.01)
-    epochs = 1000
 
     gru = training(
         model=gru,
         optimizer=optimizer,
         dataset_train=dataset_train,
         dataset_test=dataset_test,
-        epochs=epochs,
+        epochs=GRU_EPOCHS,
         loss_fn=cross_entropy_loss_mask_waiting,
         scheduler=True,
-        )
+    )
 
     torch.save(gru.state_dict(), path_gru)
     print("Trained GRU parameters saved to " + path_gru)
 else:
     gru.load_state_dict(torch.load(path_gru, map_location='cpu'))
-    
-    
+
+
 # -------------------------------------------------------------------------------------------
 # ANALYSIS
 # -------------------------------------------------------------------------------------------
@@ -119,9 +138,7 @@ else:
 estimator.eval()
 gru.eval().to(torch.device('cpu'))
 
-# general analysis
-# model evaluation (average trial likelihood)
-
+# General analysis: model evaluation (average trial likelihood)
 print(analysis_model_evaluation(
     dataset=dataset_train,
     spice_model=estimator,
@@ -134,6 +151,7 @@ print(analysis_model_evaluation(
     gru_model=gru,
 ))
 
+
 # -------------------------------------------------------------------------------------------
 # GENERATIVE BENCHMARKING
 # -------------------------------------------------------------------------------------------
@@ -141,14 +159,12 @@ print(analysis_model_evaluation(
 from weinhardt2026.studies.hwang2026.benchmarking_hwang2026 import generate_behavior
 from weinhardt2026.studies.hwang2026.analysis_generative import analysis_generative_behavior
 
-output_dir = 'weinhardt2026/studies/hwang2026/data'
-
 # Generate behavior for GRU
 gru.eval().to(torch.device('cpu'))
 dataset_gen_gru = generate_behavior(
     model=gru,
     dataset=dataset,
-    n_trials=20,
+    n_trials=N_GENERATED_TRIALS,
     save_csv=f'{output_dir}/gen_gru.csv',
 )
 
@@ -159,17 +175,17 @@ estimator.eval()
 dataset_gen_spice_rnn = generate_behavior(
     model=estimator,
     dataset=dataset,
-    n_trials=20,
+    n_trials=N_GENERATED_TRIALS,
     save_csv=f'{output_dir}/gen_spice_rnn.csv',
 )
 
-# Generate behavior for SPICE (SINDy mode)
+# Generate behavior for SPICE-SYM
 estimator.use_sindy(True)
 estimator.eval()
 dataset_gen_spice = generate_behavior(
     model=estimator,
     dataset=dataset,
-    n_trials=20,
+    n_trials=N_GENERATED_TRIALS,
     save_csv=f'{output_dir}/gen_spice.csv',
 )
 
@@ -179,5 +195,5 @@ analysis_generative_behavior(
     dataset_gru=dataset_gen_gru,
     dataset_spice_rnn=dataset_gen_spice_rnn,
     dataset_spice=dataset_gen_spice,
-    output_dir='weinhardt2026/studies/hwang2026/results',
+    output_dir=results_dir,
 )

--- a/weinhardt2026/studies/hwang2026/spice_hwang2026.py
+++ b/weinhardt2026/studies/hwang2026/spice_hwang2026.py
@@ -157,10 +157,17 @@ class SpiceModel(BaseModel):
 def cross_entropy_loss_mask_waiting(prediction, target, label_smoothing: float = 0.):
     
     n_actions = target.shape[-1]
+    waiting_action = n_actions - 1
     
     prediction = prediction.reshape(-1, n_actions)
     target = torch.argmax(target.reshape(-1, n_actions), dim=1)
     
-    non_waiting_mask = target != 4  # filters where ID1 is just waiting -> that way we are dropping waiting as an action category
+    non_waiting_mask = target != waiting_action
+    if not non_waiting_mask.any():
+        return prediction.sum() * 0.
     
-    return torch.nn.functional.cross_entropy(prediction[non_waiting_mask], target[non_waiting_mask])
+    return torch.nn.functional.cross_entropy(
+        prediction[non_waiting_mask],
+        target[non_waiting_mask],
+        label_smoothing=label_smoothing,
+    )


### PR DESCRIPTION
  The pipeline now:
  - loads the processed dataset
  - trains or reloads SPICE and GRU models
  - generates synthetic dyadic behavior for:
    - GRU
    - SPICE-RNN
    - SPICE-SYM
  - saves summary tables and violin plots for the generative behavior metrics

Main Changes:
Added a closed-loop dyadic behavior generator. For each valid empirical interaction session, the two apes interact using the trained model. The generator keeps the SPICE dataset convention intact:

  - `xs` stores the model input condition
  - `ys` stores the next generated focal response
The generated CSVs are written so they can be loaded again with csv_to_dataset function and recover the same valid xs -> ys transitions.

  The behavioral analysis was updated to evaluate focal responses from ys, while using partner actions and ID/rank information from xs. This avoids mixing up unput actions with response targets.

We get:
  - action frequencies
  - switching probability
  - grooming probability by sender rank relation
  - P(Next Groom | Partner Action)
  - rank-split conditional grooming probabilities

 The waiting-mask loss was also corrected for the current 4-action  setup. Waiting is action `3`, so the mask now uses `n_actions - 1` instead of the previous hardcoded value (that was a bug in the code)